### PR TITLE
Improve web push error handling

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -94,7 +94,11 @@ func handleWebPush(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	internal.SendToAllSubscribers(req)
+	err = internal.SendToAllSubscribers(req)
+	if err != nil {
+		generateAndSendResponse(w, "Failed to send web push notifications", http.StatusInternalServerError)
+		return
+	}
 	generateAndSendResponse(w, "Web push notifications sent", http.StatusOK)
 }
 


### PR DESCRIPTION
# Pull Request: Improve Error Handling for Web Push Subscriptions

This pull request enhances the error handling for failing web push subscriptions. Previously, since push requests were executed within goroutines, errors were only logged internally and not reported back to the caller.

To address this, an atomic boolean was introduced to track whether any errors occurred during the push requests. While detailed error information is logged for debugging purposes, the /api/webpush endpoint only returns a generic error message to the caller. This approach avoids exposing internal details about subscription failures, thereby improving security and privacy.