### PR TITLE
Fix wrong mail content type and keys logging.

### DIFF
--- a/internal/keys.go
+++ b/internal/keys.go
@@ -24,12 +24,12 @@ func SetVapidKeys() error {
 		if err != nil {
 			return fmt.Errorf("error generating VAPID keys: %v", err)
 		}
+		log.Println("VAPID keys generated and saved to disk")
 	}
 
 	VapidPublicKey = publicKey
 	vapidPrivateKey = privateKey
 
-	log.Println("VAPID keys generated and saved to disk")
 	return nil
 }
 

--- a/internal/mail.go
+++ b/internal/mail.go
@@ -73,6 +73,7 @@ func SendMail(request NotificationRequest) error {
 }
 
 func extractEmailDetails(request NotificationRequest) (subject string, contentType string, body string) {
+	contentType = request.ContentType
 	if len(contentType) == 0 {
 		contentType = "text/plain"
 	}


### PR DESCRIPTION
## Changes
- Fixed a bug where the mail content type was always set to text/plain instead of the specified content type
- Fixed incorrect logging that stated new keys to be generated even though they were loaded from disk