### PR TITLE
Multi-stage Dockerfile to reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
-FROM golang:latest
+# This multi-stage Dockerfile is used to keep the resulting docker image as small as possible.
+# See https://docs.docker.com/build/building/multi-stage/
 
+# The build stage is used to build the application to an executable.
+FROM golang:alpine AS build
 WORKDIR /app
-
+# The sqlite driver library (gorm.io/driver/sqlite, i.e. indirectly github.com/mattn/go-sqlite3) uses cgo to link sqlite and thus requires the gcc C compiler infrastructure.
+RUN apk add gcc libc-dev
 COPY . .
-
 RUN go mod download
+RUN CGO_ENABLED=1 go build ./cmd/notify
 
-RUN go build ./cmd/notify
-
+# The execute stage is as small as possible and only copies the executable and files that are actually needed at runtime from the build stage.
+FROM alpine
+WORKDIR /app
+# The musl-libc provided by the alpine image is not sufficient for cgo (used for sqlite), so install a glibc.
+RUN apk add --no-cache libc-dev
+COPY --from=build /app/template ./template
+COPY --from=build /app/notify ./notify
 EXPOSE 8080
-
 CMD ["./notify"]

--- a/internal/database.go
+++ b/internal/database.go
@@ -2,9 +2,12 @@ package internal
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"path"
+
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"log"
 )
 
 var (
@@ -13,7 +16,14 @@ var (
 )
 
 func InitDatabase() error {
-	var err error
+	// Ensure that all directories of the DatabasePath exists.
+	// Otherwise, sqlite will fail when trying to open the database file, i.e. DatabasePath.
+	databaseParentDirectoryPath := path.Dir(DatabasePath)
+	err := os.MkdirAll(databaseParentDirectoryPath, 0775)
+	if err != nil {
+		return fmt.Errorf("failed to create parent directories '%s' of the database path: %w", databaseParentDirectoryPath, err)
+	}
+
 	Connection, err = gorm.Open(sqlite.Open(DatabasePath), &gorm.Config{})
 
 	if err != nil {


### PR DESCRIPTION
This PR improves (i.e. decreases) the size of the docker image produced by the `Dockerfile` by making use of a [multi-stage build](https://docs.docker.com/build/building/multi-stage/).

The [`golang:alpine`](https://hub.docker.com/_/golang) docker image is used for building the application to an executable. After that, a pure [`alpine`](https://hub.docker.com/_/alpine) container is used to execute the application. This decreases the size of the resulting docker image from 1.04&nbsp;GB to 35.6&nbsp;MB (x29 times smaller). This improves (i.e. decreases) the build time of the container as well because less has to be downloaded.

Since the full source code directory structure is not copied to the execute stage/container to keep the final docker image as small as possible, the directory `internal/sqlite/` is missing, which causes [`sqlite.Open(DatabasePath)`](https://github.com/JaKu01/GoNotify/blob/ac9bbe896f8cd926e409a3283d57da75d7c2017a/internal/database.go#L17) to fail. Therefore, it is now ensured that the database directory path exists, i.e. that all directories of the path are created if necessary. This is also useful if the application is run without docker, outside of its source directory, e.g. if the application is installed into some bin directory using `go install`.