### PR TITLE
Fix docker-compose.yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,4 +14,6 @@ services:
       - EMAIL=${EMAIL}
       - EMAIL_PASSWORD=${EMAIL_PASSWORD}
       - TZ=Europe/Berlin
+    ports:
+      - 8080:8080
     restart: 'unless-stopped'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,10 +14,4 @@ services:
       - EMAIL=${EMAIL}
       - EMAIL_PASSWORD=${EMAIL_PASSWORD}
       - TZ=Europe/Berlin
-    networks:
-      - home_network
     restart: 'unless-stopped'
-
-networks:
-  home_network:
-    external: true


### PR DESCRIPTION
This PR removes the docker network called `home_network` from `docker-compose.yaml` and exposes the application docker port by default.

I found no explanation on how to set up this external docker network called `home_network`, so I guess it is something specific to your setup. To get the application running, it either has to be created manually or removed from the `docker-compose.yaml`, which is what I decided to do because I could not see any reason for the network. Also, the application port was not exposed by default, so I added a `port: - 8080:8080` to the `docker-compose.yaml`.